### PR TITLE
✨ feat: add order create API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,17 @@ dependencies {
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // openFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-okhttp:13.6'
+
+    // zipkin
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.github.openfeign:feign-micrometer'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/tunaforce/order/common/config/FeignConfig.java
+++ b/src/main/java/com/tunaforce/order/common/config/FeignConfig.java
@@ -1,0 +1,16 @@
+package com.tunaforce.order.common.config;
+
+import feign.okhttp.OkHttpClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.tunaforce.order.repository.feign")
+public class FeignConfig {
+
+    @Bean
+    public OkHttpClient client() {
+        return new OkHttpClient();
+    }
+}

--- a/src/main/java/com/tunaforce/order/common/config/JpaConfig.java
+++ b/src/main/java/com/tunaforce/order/common/config/JpaConfig.java
@@ -6,12 +6,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.UUID;
+
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
 
     @Bean
-    public AuditorAware<String> auditorProvider() {
+    public AuditorAware<UUID> auditorProvider() {
         return new AuditAwareImpl();
     }
 }

--- a/src/main/java/com/tunaforce/order/common/entity/AuditAwareImpl.java
+++ b/src/main/java/com/tunaforce/order/common/entity/AuditAwareImpl.java
@@ -1,15 +1,28 @@
 package com.tunaforce.order.common.entity;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public class AuditAwareImpl implements AuditorAware<String> {
+public class AuditAwareImpl implements AuditorAware<UUID> {
 
     @Override
-    public Optional<String> getCurrentAuditor() {
-        // TODO createdBy, updatedBy를 위한 로그인한 유저 id 받아오기
+    public Optional<UUID> getCurrentAuditor() {
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
 
-        return Optional.ofNullable(null);
+        // check type & casting
+        if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
+            HttpServletRequest request = servletRequestAttributes.getRequest();
+            String userId = request.getHeader("X-USER-ID");
+
+            return Optional.of(UUID.fromString(userId));
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/tunaforce/order/common/exception/OrderException.java
+++ b/src/main/java/com/tunaforce/order/common/exception/OrderException.java
@@ -10,6 +10,8 @@ public enum OrderException {
 
     // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
+    UNSUFFICIENT_PRODUCT_QUANTITY(HttpStatus.CONFLICT, "상품 재고가 부족합니다."),
+    PRODUCT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서비스가 동작하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/tunaforce/order/controller/OrderController.java
+++ b/src/main/java/com/tunaforce/order/controller/OrderController.java
@@ -1,9 +1,12 @@
 package com.tunaforce.order.controller;
 
+import com.tunaforce.order.dto.request.OrderCreateRequestDto;
 import com.tunaforce.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/orders")
@@ -11,4 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<Void> createOrder(
+            @RequestBody OrderCreateRequestDto orderCreateRequestDto,
+            @RequestHeader("X-USER-ID") UUID userId // FIXME 임시
+    ) {
+        orderService.createOrder(orderCreateRequestDto, userId);
+
+        return ResponseEntity.created(null)
+                .body(null);
+    }
 }

--- a/src/main/java/com/tunaforce/order/dto/request/OrderCreateRequestDto.java
+++ b/src/main/java/com/tunaforce/order/dto/request/OrderCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.tunaforce.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record OrderCreateRequestDto(
+        @NotNull(message = "주문 상품 id 값을 입력해주세요.")
+        UUID productId,
+
+        @NotNull(message = "요청 업체 id 값을 입력해주세요.")
+        UUID receiveCompanyId,
+
+        @NotNull(message = "상품 주문 수량을 입력해주세요.") @Min(value = 0, message = "상품 주문 수량은 최소 1 이상이어야 합니다.")
+        Integer orderQuantity,
+
+        String requestMemo
+) {
+}

--- a/src/main/java/com/tunaforce/order/entity/Order.java
+++ b/src/main/java/com/tunaforce/order/entity/Order.java
@@ -3,6 +3,7 @@ package com.tunaforce.order.entity;
 import com.tunaforce.order.common.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,4 +37,36 @@ public class Order extends Timestamped {
     @Column(name = "order_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
+
+    @Builder
+    public Order(UUID supplyCompanyId, UUID receiveCompanyId, Integer price, Integer quantity, String requestMemo, OrderStatus status) {
+        this.supplyCompanyId = supplyCompanyId;
+        this.receiveCompanyId = receiveCompanyId;
+        this.price = price;
+        this.quantity = quantity;
+        this.requestMemo = requestMemo;
+        this.status = status;
+    }
+
+    public void setProductInfo(UUID supplyCompanyId, Integer price) {
+        this.supplyCompanyId = supplyCompanyId;
+        this.price = price;
+    }
+
+    // set order status
+    public void setStatusPrepared() {
+        this.status = OrderStatus.PREPARED;
+    }
+
+    public void setStatusPaid() {
+        this.status = OrderStatus.PAID;
+    }
+
+    public void setStatusShipping() {
+        this.status = OrderStatus.SHIPPING;
+    }
+
+    public void setStatusDelivered() {
+        this.status = OrderStatus.DELIVERED;
+    }
 }

--- a/src/main/java/com/tunaforce/order/entity/OrderStatus.java
+++ b/src/main/java/com/tunaforce/order/entity/OrderStatus.java
@@ -9,8 +9,8 @@ public enum OrderStatus {
 
     PENDING("PENDING"), // 주문 요청
     PAID("PAID"), // 결제 완료
-    PREPARING("PREPARING"), // 상품 준비중
-    SHIPPED("SHIPPED"), // 배송 출발
+    PREPARED("PREPARED"), // 상품 준비 완료
+    SHIPPING("SHIPPING"), // 배송 중
     DELIVERED("DELIVERED"), // 배송 완료
 
     CANCELLED("CANCELLED"), // 주문 취소

--- a/src/main/java/com/tunaforce/order/entity/OrderStatus.java
+++ b/src/main/java/com/tunaforce/order/entity/OrderStatus.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum OrderStatus {
 
     PENDING("PENDING"), // 주문 요청
-    PAID("PAID"), // 결제 완료
     PREPARED("PREPARED"), // 상품 준비 완료
+    PAID("PAID"), // 결제 완료
     SHIPPING("SHIPPING"), // 배송 중
     DELIVERED("DELIVERED"), // 배송 완료
 

--- a/src/main/java/com/tunaforce/order/repository/feign/auth/AuthFeignClient.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/auth/AuthFeignClient.java
@@ -1,0 +1,11 @@
+package com.tunaforce.order.repository.feign.auth;
+
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(
+        name = "auth-service",
+        url = "localhost:3350",
+        path = "/internal/auth",
+        fallbackFactory = AuthFeignFallbackFactory.class)
+public interface AuthFeignClient {
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/auth/AuthFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/auth/AuthFeignFallbackFactory.java
@@ -1,0 +1,15 @@
+package com.tunaforce.order.repository.feign.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AuthFeignFallbackFactory implements FallbackFactory<AuthFeignClient> {
+
+    @Override
+    public AuthFeignClient create(Throwable cause) {
+        return null;
+    }
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/delivery/DeliveryFeignClient.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/delivery/DeliveryFeignClient.java
@@ -1,0 +1,16 @@
+package com.tunaforce.order.repository.feign.delivery;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name = "delivery-service",
+        url = "localhost:3370",
+        path = "/internal/deliveries",
+        fallbackFactory = DeliveryFeignFallbackFactory.class
+)
+public interface DeliveryFeignClient {
+
+    @PostMapping("/order-delivery/create-delivery")
+    void createOrderDelivery();
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/delivery/DeliveryFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/delivery/DeliveryFeignFallbackFactory.java
@@ -1,0 +1,13 @@
+package com.tunaforce.order.repository.feign.delivery;
+
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeliveryFeignFallbackFactory implements FallbackFactory<DeliveryFeignClient> {
+
+    @Override
+    public DeliveryFeignClient create(Throwable cause) {
+        return null;
+    }
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignClient.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignClient.java
@@ -1,0 +1,27 @@
+package com.tunaforce.order.repository.feign.product;
+
+import com.tunaforce.order.repository.feign.product.dto.request.ProductReduceStockRequestDto;
+import com.tunaforce.order.repository.feign.product.dto.response.ProductReduceStockResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "product-service",
+        url = "localhost:3390",
+        path = "/internal/products",
+        fallbackFactory = ProductFeignFallbackFactory.class
+)
+public interface ProductFeignClient {
+
+    @PatchMapping("/{productId}/order-product/decrease-stock")
+    ProductReduceStockResponseDto reduceStock(
+            @PathVariable UUID productId,
+            @RequestBody ProductReduceStockRequestDto productReduceStockRequestDto,
+            @RequestHeader("X-USER-ID") UUID userId
+    );
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignFallbackFactory.java
@@ -29,7 +29,7 @@ public class ProductFeignFallbackFactory implements FallbackFactory<ProductFeign
                     throw new CustomRuntimeException(OrderException.PRODUCT_NOT_FOUND);
                 }
 
-                if (cause instanceof FeignException.Forbidden) {
+                if (cause instanceof FeignException.Conflict) {
                     throw new CustomRuntimeException(OrderException.UNSUFFICIENT_PRODUCT_QUANTITY);
                 }
 

--- a/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/product/ProductFeignFallbackFactory.java
@@ -1,0 +1,40 @@
+package com.tunaforce.order.repository.feign.product;
+
+import com.tunaforce.order.common.exception.CustomRuntimeException;
+import com.tunaforce.order.common.exception.OrderException;
+import com.tunaforce.order.repository.feign.product.dto.request.ProductReduceStockRequestDto;
+import com.tunaforce.order.repository.feign.product.dto.response.ProductReduceStockResponseDto;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class ProductFeignFallbackFactory implements FallbackFactory<ProductFeignClient> {
+
+    @Override
+    public ProductFeignClient create(Throwable cause) {
+        return new ProductFeignClient() {
+
+            @Override
+            public ProductReduceStockResponseDto reduceStock(
+                    UUID productId,
+                    ProductReduceStockRequestDto productReduceStockRequestDto,
+                    UUID userId
+            ) {
+                if (cause instanceof FeignException.NotFound) {
+                    throw new CustomRuntimeException(OrderException.PRODUCT_NOT_FOUND);
+                }
+
+                if (cause instanceof FeignException.Forbidden) {
+                    throw new CustomRuntimeException(OrderException.UNSUFFICIENT_PRODUCT_QUANTITY);
+                }
+
+                throw new CustomRuntimeException(OrderException.PRODUCT_SERVICE_UNAVAILABLE);
+            }
+        };
+    }
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/product/dto/request/ProductReduceStockRequestDto.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/product/dto/request/ProductReduceStockRequestDto.java
@@ -1,0 +1,6 @@
+package com.tunaforce.order.repository.feign.product.dto.request;
+
+public record ProductReduceStockRequestDto(
+        Integer quantity
+) {
+}

--- a/src/main/java/com/tunaforce/order/repository/feign/product/dto/response/ProductReduceStockResponseDto.java
+++ b/src/main/java/com/tunaforce/order/repository/feign/product/dto/response/ProductReduceStockResponseDto.java
@@ -1,0 +1,9 @@
+package com.tunaforce.order.repository.feign.product.dto.response;
+
+import java.util.UUID;
+
+public record ProductReduceStockResponseDto(
+        UUID supplyCompanyId,
+        Integer price
+) {
+}

--- a/src/main/java/com/tunaforce/order/service/OrderService.java
+++ b/src/main/java/com/tunaforce/order/service/OrderService.java
@@ -1,12 +1,60 @@
 package com.tunaforce.order.service;
 
+import com.tunaforce.order.dto.request.OrderCreateRequestDto;
+import com.tunaforce.order.entity.Order;
+import com.tunaforce.order.entity.OrderStatus;
+import com.tunaforce.order.repository.feign.auth.AuthFeignClient;
+import com.tunaforce.order.repository.feign.delivery.DeliveryFeignClient;
+import com.tunaforce.order.repository.feign.product.ProductFeignClient;
+import com.tunaforce.order.repository.feign.product.dto.request.ProductReduceStockRequestDto;
+import com.tunaforce.order.repository.feign.product.dto.response.ProductReduceStockResponseDto;
 import com.tunaforce.order.repository.jpa.OrderJpaRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
 
+    private final AuthFeignClient authFeignClient;
+    private final ProductFeignClient productFeignClient;
+    private final DeliveryFeignClient deliveryFeignClient;
+
     private final OrderJpaRepository orderJpaRepository;
+
+    @Transactional
+    public void createOrder(OrderCreateRequestDto request, UUID userId) {
+        // 유저 역할에 따라 주문 생성에 요청된 업체와 로그인한 유저의 허브 또는 업체와의 관계가 유효한지 검증
+
+        // 주문 생성
+        Order order = Order.builder()
+                .receiveCompanyId(request.receiveCompanyId())
+                .quantity(request.orderQuantity())
+                .requestMemo(request.requestMemo())
+                .status(OrderStatus.PENDING)
+                .build();
+
+        // 재고 차감
+        ProductReduceStockResponseDto productResponse = productFeignClient.reduceStock(
+                request.productId(),
+                new ProductReduceStockRequestDto(request.orderQuantity()),
+                userId
+        );
+
+        order.setProductInfo(productResponse.supplyCompanyId(), productResponse.price());
+        order.setStatusPrepared();
+
+        // 결제(가정)
+        order.setStatusPaid();
+
+        // 배달 생성
+        deliveryFeignClient.createOrderDelivery();
+        order.setStatusShipping();
+
+        // 주문 영속화
+        orderJpaRepository.save(order);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,17 +9,3 @@ spring:
     openfeign:
       circuitbreaker:
         enabled: true
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://0.0.0.0:3310/eureka
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-
-  tracing:
-    sampling:
-      probability: 1.0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: order-service
+    name: orders
 
   profiles:
     active: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,7 @@ spring:
       circuitbreaker:
         enabled: true
 
+eureka:
+  client:
+    service-url:
+      defaultZone: http://0.0.0.0:3310/eureka

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,12 @@ eureka:
   client:
     service-url:
       defaultZone: http://0.0.0.0:3310/eureka
+
+management:
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"
+
+  tracing:
+    sampling:
+      probability: 1.0


### PR DESCRIPTION
## 작업 내용
특정 상품에 대한 주문 생성 API

## 관련 이슈
#3 

## 작업 상세 내용
- 서비스 로직 순서
  > 유저 관련 검증(허브, 업체 등) -> 주문 생성(PENDING) -> 재고 차감(PREPARED) -> 결제(가정, PAID) -> 배달 생성(SHIPPING) -> 영속화

- 주문 상태 값 변경
  > 상태 순서 PENDING -> PREPARED -> PAID -> SHIPPING -> DELIVERED
  - PREPARRING -> PREPARED
  - SHIPPING -> SHIPPED

- Feign 통신 시 Http PATCH method 사용불가 이슈
  - ApachHttpClient vs OkHttpClient
  - 일단 사용하기 편리하고 가볍다는 장점이 있는 OkHttpClient 사용했습니다.
  - 자세히 알아보고 후에 변경할게요.

- Dependency 추가
  - Zipkin, OkHttpClient 추가 했습니다.